### PR TITLE
Retrait de flickr dans les contacts en bas

### DIFF
--- a/_data/contact.json
+++ b/_data/contact.json
@@ -20,10 +20,6 @@
     {
       "label": "YouTube",
       "url": "https://www.youtube.com/channel/UCtvgOm5GYpuuEL6pXoEoylg"
-    },
-    {
-      "label": "Flickr",
-      "url": "https://www.flickr.com/photos/138571979@N05"
     }
   ]
 }


### PR DESCRIPTION
C'est pas tant un contact, et c'est vraiment pas à jour.
On pourrait possiblement le remplacer par notre google photos though.