### PR TITLE
Add marging between events on mobile and use the same height on desktop

### DIFF
--- a/_pages/index.html
+++ b/_pages/index.html
@@ -86,14 +86,16 @@ layout: page
 <ul class="grid grid-3">
   {% for event in site.data.events %}
     <li class="event" data-timestamp="{{ event.date_unix }}">
-      <p>
-        <b>{{ event.name }}</b><br/>
-        <span class="faded">{{ event.date }}</span>
-      </p>
-      <p>{{ event.description }}</p>
-      {% if event.url != "" %}
-        <p><a target="_blank" href="{{event.url}}">Plus d'informations →</a></p>
-      {% endif %}
+      <div class="content">
+        <p>
+          <b>{{ event.name }}</b><br/>
+          <span class="faded">{{ event.date }}</span>
+        </p>
+        <p>{{ event.description }}</p>
+        {% if event.url != "" %}
+          <p><a target="_blank" href="{{event.url}}">Plus d'informations →</a></p>
+        {% endif %}
+      </div>
     </li>
   {% endfor %}
 </ul>

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -80,10 +80,18 @@ ul.grid {
     @media (max-width: 560px){
       grid-template-columns: repeat(1, 1fr);
     }
-    li {
+    li .content {
       background: linear-gradient(135deg, hsl(160, 0%, 99%), hsl(151, 50%, 94%));
       padding: 1em;
       border-radius: 5px;
+
+      @media (min-width: 768px) {
+        height: 100%;
+      }
+
+      @media (max-width: 767px){
+        margin-bottom: 10px;
+      } 
     }
   }
 
@@ -155,6 +163,10 @@ ul.grid {
 
 body{
   overflow-x:hidden;
+}
+
+.event{
+  height: 100%;
 }
 
 .stripes{


### PR DESCRIPTION
Quelques changements mineurs à l'affichage des événements.

Sur desktop j'ai fait que tout les events on la même hauteur, je crois que ça sort mieux.
Sur mobile j'ai ajouté du spacing entre les events, c'était un peu collé :P. 

# Desktop
## Before
![image](https://user-images.githubusercontent.com/25696312/65990136-0a725c80-e459-11e9-8cff-f79b348ae8df.png)

## After
![image](https://user-images.githubusercontent.com/25696312/65990159-16f6b500-e459-11e9-9585-a0066f34212c.png)


# Mobile
## Before
![image](https://user-images.githubusercontent.com/25696312/65990201-270e9480-e459-11e9-84c3-6bfd9284238f.png)

## After
![image](https://user-images.githubusercontent.com/25696312/65990231-368ddd80-e459-11e9-8768-c57eb71bb3bd.png)
