### PR TITLE
Ajout discord et retrait slack

### DIFF
--- a/_data/contact.json
+++ b/_data/contact.json
@@ -6,9 +6,9 @@
   },
   "social": [
     {
-      "label": "Slack",
-      "url": "https://jdis.slack.com/"
-    },
+      "label":"Discord",
+      "url":"https://discord.gg/D8fbmPcKTT"
+    }
     {
       "label": "Facebook",
       "url": "https://www.facebook.com/JDISherbrooke/"


### PR DESCRIPTION
ajout de discord qui est notre nouvelle plateforme de communication et retrait de slack qui n'est plus aucunement utilisé